### PR TITLE
Adding link to sample XML files

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,11 @@ cd $GOPATH/src/github.com/talkkonnect/talkkonnect
 
 ` /home/talkkonnect/gocode/src/github.com/talkkonnect/talkkonnect/talkkonnect.xml`
 
+##### Sample XML files can be found from sample-configs folder: #####
+
+https://github.com/talkkonnect/talkkonnect/tree/main/sample-configs
+
+
 ##### Build talKKonnect and test connection to your Mumble server. #####
 
 ` go build -o /home/talkkonnect/bin/talkkonnect cmd/talkkonnect/main.go `


### PR DESCRIPTION
Talkkonnect documentation is really good but link to sample XML files were missing. Adding it here.